### PR TITLE
Updated media nodes & added EMPTY_CHILDREN const

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,11 +56,13 @@ type TListItemElement = {
 type TImageElement = {
   type: 'image';
   source: string;
+  children: TCustomText[];
 };
 
 type TVideoElement = {
   type: 'video';
   source: string;
+  children: TCustomText[];
 };
 
 type TMediaElement = TImageElement | TVideoElement;
@@ -105,6 +107,13 @@ const serializeToString = (value: string): string => {
     .join(' ');
 };
 
+const EMPTY_CHILDREN: TCustomText[] = [
+  {
+    text: '',
+    type: 'text',
+  },
+];
+
 export {
   LeafChild,
   TWithLinksEditor,
@@ -126,4 +135,5 @@ export {
   TTextElement,
   TMediaElement,
   serializeToString,
+  EMPTY_CHILDREN,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplicity-tech/sim-slate-types",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Typings for all slate related simplicity projects",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Updated media nodes to contain children attribute to conform with slate spec
- Added EMPTY_CHILDREN const to re-use across applications where necessary